### PR TITLE
Select item for estimation modification

### DIFF
--- a/app/admin/rates/page.tsx
+++ b/app/admin/rates/page.tsx
@@ -3,7 +3,7 @@ import { DashboardHeader } from "@/components/dashboard-header"
 import { RatesTable } from "@/components/rates-table"
 
 export default async function AdminRatesPage() {
-  const [rates, units] = await Promise.all([
+  const [rates, units, estimates] = await Promise.all([
     prisma.rateLibrary.findMany({
       include: {
         unit: true,
@@ -11,6 +11,10 @@ export default async function AdminRatesPage() {
       orderBy: { createdAt: "desc" },
     }),
     prisma.unitMaster.findMany({
+      orderBy: { createdAt: "desc" },
+    }),
+    prisma.estimate.findMany({
+      select: { id: true, title: true, category: true },
       orderBy: { createdAt: "desc" },
     }),
   ])
@@ -27,7 +31,7 @@ export default async function AdminRatesPage() {
             </p>
           </div>
           <div className="animate-fade-in">
-            <RatesTable rates={rates} units={units} />
+            <RatesTable rates={rates} units={units} estimates={estimates} />
           </div>
         </div>
       </main>

--- a/components/rates-table.tsx
+++ b/components/rates-table.tsx
@@ -1,14 +1,20 @@
 "use client"
 
-import { useState } from "react"
+import { useEffect, useRef, useState } from "react"
+import { useRouter } from "next/navigation"
 import { Button } from "@/components/ui/button"
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
 import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "@/components/ui/table"
 import { Input } from "@/components/ui/input"
-import { PlusCircle, Edit, Trash2, Search } from "lucide-react"
+import { Checkbox } from "@/components/ui/checkbox"
+import { Dialog, DialogContent, DialogDescription, DialogFooter, DialogHeader, DialogTitle } from "@/components/ui/dialog"
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select"
+import { Label } from "@/components/ui/label"
+import { PlusCircle, Edit, Trash2, Search, Loader2, Plus } from "lucide-react"
 import { AddRateDialog } from "@/components/add-rate-dialog"
 import { EditRateDialog } from "@/components/edit-rate-dialog"
 import { DeleteRateDialog } from "@/components/delete-rate-dialog"
+import { createWorkItemsFromRates } from "@/lib/actions/work-items"
 
 interface Rate {
   id: string
@@ -31,17 +37,31 @@ interface Unit {
   unitSymbol: string
 }
 
+interface EstimateOption {
+  id: string
+  title: string
+  category: string
+}
+
 interface RatesTableProps {
   rates: Rate[]
   units: Unit[]
+  estimates: EstimateOption[]
 }
 
-export function RatesTable({ rates: initialRates, units }: RatesTableProps) {
+export function RatesTable({ rates: initialRates, units, estimates }: RatesTableProps) {
   const [rates, setRates] = useState(initialRates)
   const [searchQuery, setSearchQuery] = useState("")
   const [addDialogOpen, setAddDialogOpen] = useState(false)
   const [editRate, setEditRate] = useState<Rate | null>(null)
   const [deleteId, setDeleteId] = useState<string | null>(null)
+  const [selectedRateIds, setSelectedRateIds] = useState<Set<string>>(new Set())
+  const [addToEstimateOpen, setAddToEstimateOpen] = useState(false)
+  const [targetEstimateId, setTargetEstimateId] = useState<string>("")
+  const [quantity, setQuantity] = useState<string>("1")
+  const [isSubmitting, setIsSubmitting] = useState(false)
+  const selectAllRef = useRef<HTMLInputElement | null>(null)
+  const router = useRouter()
 
   const filteredRates = rates.filter(
     (rate) =>
@@ -67,6 +87,55 @@ export function RatesTable({ rates: initialRates, units }: RatesTableProps) {
     if (response.ok) {
       setRates(rates.filter((r) => r.id !== id))
       setDeleteId(null)
+    }
+  }
+
+  const isAllSelected = filteredRates.length > 0 && filteredRates.every((r) => selectedRateIds.has(r.id))
+  const isIndeterminate = selectedRateIds.size > 0 && !isAllSelected
+
+  useEffect(() => {
+    if (selectAllRef.current) {
+      selectAllRef.current.indeterminate = isIndeterminate
+    }
+  }, [isIndeterminate])
+
+  const toggleSelectAll = (checked: boolean) => {
+    if (checked) {
+      setSelectedRateIds(new Set(filteredRates.map((r) => r.id)))
+    } else {
+      setSelectedRateIds(new Set())
+    }
+  }
+
+  const toggleSelectOne = (id: string, checked: boolean) => {
+    const next = new Set(selectedRateIds)
+    if (checked) next.add(id)
+    else next.delete(id)
+    setSelectedRateIds(next)
+  }
+
+  const handleAddSelectedToEstimate = async () => {
+    try {
+      setIsSubmitting(true)
+      const qty = parseFloat(quantity)
+      const result = await createWorkItemsFromRates({
+        estimateId: targetEstimateId,
+        rateIds: Array.from(selectedRateIds),
+        quantity: isNaN(qty) || qty <= 0 ? 1 : qty,
+      })
+      if (!result.success) {
+        throw new Error(result.error || "Failed to add to estimate")
+      }
+      setAddToEstimateOpen(false)
+      setSelectedRateIds(new Set())
+      setTargetEstimateId("")
+      setQuantity("1")
+      const redirectId = (Array.isArray(result.data) && result.data.length > 0) ? result.data[0].estimateId : targetEstimateId
+      if (redirectId) router.push(`/estimates/${redirectId}/work-items`)
+    } catch (e) {
+      console.error(e)
+    } finally {
+      setIsSubmitting(false)
     }
   }
 
@@ -97,9 +166,34 @@ export function RatesTable({ rates: initialRates, units }: RatesTableProps) {
               />
             </div>
           </div>
+          <div className="mb-2 flex items-center justify-between">
+            <div className="text-sm text-muted-foreground">
+              {selectedRateIds.size > 0 ? `${selectedRateIds.size} selected` : ""}
+            </div>
+            <div className="flex gap-2">
+              <Button
+                variant="outline"
+                size="sm"
+                disabled={selectedRateIds.size === 0 || estimates.length === 0}
+                onClick={() => setAddToEstimateOpen(true)}
+              >
+                <Plus className="h-4 w-4 mr-2" />
+                Add to Estimate
+              </Button>
+            </div>
+          </div>
+
           <Table>
             <TableHeader>
               <TableRow>
+                <TableHead className="w-[50px]">
+                  <Checkbox
+                    ref={selectAllRef}
+                    checked={isAllSelected}
+                    onCheckedChange={(c) => toggleSelectAll(Boolean(c))}
+                    data-select-all
+                  />
+                </TableHead>
                 <TableHead>Description</TableHead>
                 <TableHead>Unit</TableHead>
                 <TableHead>Standard Rate (₹)</TableHead>
@@ -110,13 +204,19 @@ export function RatesTable({ rates: initialRates, units }: RatesTableProps) {
             <TableBody>
               {filteredRates.length === 0 ? (
                 <TableRow>
-                  <TableCell colSpan={5} className="text-center text-muted-foreground py-8">
+                  <TableCell colSpan={6} className="text-center text-muted-foreground py-8">
                     No rates found. Add your first rate to get started.
                   </TableCell>
                 </TableRow>
               ) : (
                 filteredRates.map((rate) => (
                   <TableRow key={rate.id}>
+                    <TableCell>
+                      <Checkbox
+                        checked={selectedRateIds.has(rate.id)}
+                        onCheckedChange={(c) => toggleSelectOne(rate.id, Boolean(c))}
+                      />
+                    </TableCell>
                     <TableCell className="font-medium">{rate.description}</TableCell>
                     <TableCell>{rate.unit.unitSymbol}</TableCell>
                     <TableCell>₹{rate.standardRate.toLocaleString("en-IN", { minimumFractionDigits: 2 })}</TableCell>
@@ -151,6 +251,53 @@ export function RatesTable({ rates: initialRates, units }: RatesTableProps) {
         onOpenChange={(open) => !open && setDeleteId(null)}
         onConfirm={() => deleteId && handleDelete(deleteId)}
       />
+
+      <Dialog open={addToEstimateOpen} onOpenChange={setAddToEstimateOpen}>
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>Add selected rates to estimate</DialogTitle>
+            <DialogDescription>
+              Create work items in a chosen estimate from the selected rate library entries.
+            </DialogDescription>
+          </DialogHeader>
+          <div className="space-y-4">
+            <div className="space-y-2">
+              <Label>Estimate</Label>
+              <Select value={targetEstimateId} onValueChange={setTargetEstimateId}>
+                <SelectTrigger>
+                  <SelectValue placeholder={estimates.length ? "Select an estimate" : "No estimates available"} />
+                </SelectTrigger>
+                <SelectContent>
+                  {estimates.map((e) => (
+                    <SelectItem key={e.id} value={e.id}>
+                      <div>
+                        <div className="font-medium">{e.title}</div>
+                        <div className="text-xs text-muted-foreground">{e.category}</div>
+                      </div>
+                    </SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+            </div>
+            <div className="space-y-2">
+              <Label>Quantity for each item</Label>
+              <Input type="number" min="0" step="0.01" value={quantity} onChange={(e) => setQuantity(e.target.value)} />
+            </div>
+          </div>
+          <DialogFooter>
+            <Button variant="outline" onClick={() => setAddToEstimateOpen(false)} disabled={isSubmitting}>
+              Cancel
+            </Button>
+            <Button
+              onClick={handleAddSelectedToEstimate}
+              disabled={isSubmitting || !targetEstimateId || selectedRateIds.size === 0}
+            >
+              {isSubmitting && <Loader2 className="h-4 w-4 mr-2 animate-spin" />}
+              {isSubmitting ? "Adding..." : `Add ${selectedRateIds.size} item${selectedRateIds.size !== 1 ? "s" : ""}`}
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
     </>
   )
 }


### PR DESCRIPTION
Add functionality to select multiple rates from the admin rates page and add them as work items to a chosen estimate.

This allows users to easily create work items in an estimate by selecting existing rates from the rate library, streamlining the process of populating estimates for further modification.

---
<a href="https://cursor.com/background-agent?bcId=bc-fac27f6f-2d65-4625-bbfc-3d3c2905d5f3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-fac27f6f-2d65-4625-bbfc-3d3c2905d5f3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

