### PR TITLE
Modify estimate work item design

### DIFF
--- a/app/estimates/[id]/work-items/page.tsx
+++ b/app/estimates/[id]/work-items/page.tsx
@@ -1,7 +1,7 @@
 import { prisma } from "@/lib/db"
 import { Button } from "@/components/ui/button"
 import Link from "next/link"
-import { ArrowLeft, Download, FileSpreadsheet, Plus, Save, X, Edit, Trash2, Check } from "lucide-react"
+import { ArrowLeft, Download, FileSpreadsheet, Plus, Save, X, Edit, Trash2, Check, MoreVertical, FileText } from "lucide-react"
 import {
   DropdownMenu,
   DropdownMenuContent,
@@ -73,15 +73,26 @@ export default async function WorkItemsPage({ params }: { params: Promise<{ id: 
               <p className="text-muted-foreground">Manage work items, quantities, and calculations</p>
             </div>
             <div className="flex items-center gap-2">
+              <Link href={`/estimates/${id}/detailed`}>
+                <Button variant="outline">
+                  <FileText className="h-4 w-4 mr-2" />
+                  Detailed View
+                </Button>
+              </Link>
+              <Link href={`/estimates/${id}/abstract`}>
+                <Button>
+                  <FileText className="h-4 w-4 mr-2" />
+                  View Abstract
+                </Button>
+              </Link>
               <DropdownMenu>
                 <DropdownMenuTrigger asChild>
-                  <Button variant="outline">
-                    <Download className="h-4 w-4 mr-2" />
-                    Export
+                  <Button variant="outline" size="icon" aria-label="More actions">
+                    <MoreVertical className="h-4 w-4" />
                   </Button>
                 </DropdownMenuTrigger>
                 <DropdownMenuContent align="end">
-                  <DropdownMenuLabel>Export Options</DropdownMenuLabel>
+                  <DropdownMenuLabel>Actions</DropdownMenuLabel>
                   <DropdownMenuSeparator />
                   <DropdownMenuItem asChild>
                     <Link
@@ -125,9 +136,6 @@ export default async function WorkItemsPage({ params }: { params: Promise<{ id: 
                   </DropdownMenuItem>
                 </DropdownMenuContent>
               </DropdownMenu>
-              <Link href={`/estimates/${id}/abstract`}>
-                <Button>View Abstract</Button>
-              </Link>
             </div>
           </div>
         </div>

--- a/components/work-items-page-client.tsx
+++ b/components/work-items-page-client.tsx
@@ -342,12 +342,7 @@ export function WorkItemsPageClient({ estimate, units, rates, allWorkItems }: Wo
                 Select work items from existing estimates to add to this project.
               </p>
               
-              {/* Debug Info */}
-              <div className="text-xs text-muted-foreground bg-gray-50 p-2 rounded">
-                <p>Total work items in database: {allWorkItems.length}</p>
-                <p>Items from other estimates: {allWorkItems.filter(item => item.estimate.id !== estimate.id).length}</p>
-                <p>Current estimate ID: {estimate.id}</p>
-              </div>
+              {/* Debug Info removed for cleaner UI */}
               
               <div className="max-h-96 overflow-y-auto border rounded-lg">
                 <Table>
@@ -748,9 +743,6 @@ export function WorkItemsPageClient({ estimate, units, rates, allWorkItems }: Wo
                     <TableHead className="w-20 text-right">Height</TableHead>
                     <TableHead className="w-24 text-right">Quantity</TableHead>
                     <TableHead className="w-24 text-right">Rate (₹)</TableHead>
-                    <TableHead className="w-24 text-right">Material (₹)</TableHead>
-                    <TableHead className="w-24 text-right">Labor (₹)</TableHead>
-                    <TableHead className="w-24 text-right">Equipment (₹)</TableHead>
                     <TableHead className="w-24 text-right">Amount (₹)</TableHead>
                     <TableHead className="w-20 text-right">Actions</TableHead>
                   </TableRow>
@@ -776,9 +768,6 @@ export function WorkItemsPageClient({ estimate, units, rates, allWorkItems }: Wo
                       <TableCell className="text-right">{(item.height || 0).toFixed(2)}</TableCell>
                       <TableCell className="text-right">{getCalculatedQuantity(item).toFixed(3)}</TableCell>
                       <TableCell className="text-right">{item.rate.toFixed(2)}</TableCell>
-                      <TableCell className="text-right">{(item.materialCost || 0).toFixed(2)}</TableCell>
-                      <TableCell className="text-right">{(item.laborCost || 0).toFixed(2)}</TableCell>
-                      <TableCell className="text-right">{(item.equipmentCost || 0).toFixed(2)}</TableCell>
                       <TableCell className="text-right font-medium">
                         {item.amount.toLocaleString("en-IN", { minimumFractionDigits: 2 })}
                       </TableCell>
@@ -809,7 +798,7 @@ export function WorkItemsPageClient({ estimate, units, rates, allWorkItems }: Wo
                     </TableRow>
                   ))}
                   <TableRow className="bg-muted/50 font-bold">
-                    <TableCell colSpan={11} className="text-right">
+                    <TableCell colSpan={8} className="text-right">
                       Total Estimate:
                     </TableCell>
                     <TableCell className="text-right">


### PR DESCRIPTION
Refactor `/estimates/[id]/work-items` page header and simplify the work items table.

The header now aligns with other estimate pages by replacing the "Export" button with a compact "More" actions menu and adding a "Detailed View" button. The work items table has been simplified by removing the Material, Labor, and Equipment columns to focus on core fields, and the debug info block has been removed for a cleaner UI.

---
<a href="https://cursor.com/background-agent?bcId=bc-27d978ee-390d-4b34-9152-3181211f7eb3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-27d978ee-390d-4b34-9152-3181211f7eb3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

